### PR TITLE
Missing notification test

### DIFF
--- a/tests/Browser/InvalidAnnouncementTest.php
+++ b/tests/Browser/InvalidAnnouncementTest.php
@@ -33,6 +33,28 @@ class InvalidAnnouncementTest extends DuskTestCase
                 ->press('Shout!')
                 ->waitForText('Uh Oh!')
                 ->assertSee('Looks like you\'ve forgotten something. Try again')
+                ->visit('/stream');
+        });
+    }
+
+    /**
+     * Ensure that an announcement that fails validation does not appear in the stream
+     * No fields have been completed
+     *
+     * @group stream
+     * @group announcement
+     * @group invalid
+     * @return void
+     */
+    public function testStreamDoesNotContainAnnouncementThatFailedValidationDueToLackOfAnyData()
+    {
+        $user = User::find(3);
+
+        $this->browse(function ($broadcast) use ($user) {
+            $broadcast->loginAs($user)
+                ->visit('/shout')
+                ->assertSee('Shout!')
+                ->press('Shout!')
                 ->visit('/stream')
                 ->assertDontSeeIn('div.author', $user->fullName());
         });
@@ -59,7 +81,30 @@ class InvalidAnnouncementTest extends DuskTestCase
                 ->select('type_id', (string) AnnouncementType::ANNOUNCEMENT_ID)
                 ->press('Shout!')
                 ->waitForText('Uh Oh!')
-                ->assertSee('Looks like you\'ve forgotten something. Try again')
+                ->assertSee('Looks like you\'ve forgotten something. Try again');
+        });
+    }
+
+    /**
+     * Ensure that an announcement that fails validation does not appear in the stream
+     * Title value has not been entered
+     *
+     * @group stream
+     * @group announcement
+     * @group invalid
+     * @return void
+     */
+    public function testStreamDoesNotContainAnnouncementThatFailedValidationDueToLackOfTitle()
+    {
+        $user = User::find(3);
+
+        $this->browse(function ($broadcast) use ($user) {
+            $broadcast->loginAs($user)
+                ->visit('/shout')
+                ->assertSee('Shout!')
+                ->type('body', 'Body of the stream item')
+                ->select('type_id', (string) AnnouncementType::ANNOUNCEMENT_ID)
+                ->press('Shout!')
                 ->visit('/stream')
                 ->assertDontSeeIn('div.stream_body', 'Body of the stream item')
                 ->assertDontSeeIn('div.author', $user->fullName());
@@ -95,6 +140,32 @@ class InvalidAnnouncementTest extends DuskTestCase
     }
 
     /**
+     * Ensure that an announcement that fails validation does not appear in the stream
+     * Body value has not been entered
+     *
+     * @group stream
+     * @group announcement
+     * @group invalid
+     * @return void
+     */
+    public function testStreamDoesNotContainAnnouncementThatFailedValidationDueToLackOfBody()
+    {
+        $user = User::find(3);
+
+        $this->browse(function ($broadcast) use ($user) {
+            $broadcast->loginAs($user)
+                ->visit('/shout')
+                ->assertSee('Shout!')
+                ->type('title', 'New Stream Item')
+                ->select('type_id', (string) AnnouncementType::ANNOUNCEMENT_ID)
+                ->press('Shout!')
+                ->visit('/stream')
+                ->assertDontSeeIn('h4.shout-title', 'New Stream Item')
+                ->assertDontSeeIn('div.author', $user->fullName());
+        });
+    }
+
+    /**
      * Check that correct messaging displayed within modal for a message that fails validation
      * Announcement type has not been selected from the drop down
      *
@@ -115,8 +186,34 @@ class InvalidAnnouncementTest extends DuskTestCase
                 ->type('body', 'Body of the stream item')
                 ->press('Shout!')
                 ->waitForText('Uh Oh!')
-                ->assertSee('Looks like you\'ve forgotten something. Try again')
-                ->pause(3000);
+                ->assertSee('Looks like you\'ve forgotten something. Try again');
+        });
+    }
+
+    /**
+     * Ensure that an announcement that fails validation does not appear in the stream
+     * Type value has not been selected
+     *
+     * @group stream
+     * @group announcement
+     * @group invalid
+     * @return void
+     */
+    public function testStreamDoesNotContainAnnouncementThatFailedValidationDueToLackOfType()
+    {
+        $user = User::find(3);
+
+        $this->browse(function ($broadcast) use ($user) {
+            $broadcast->loginAs($user)
+                ->visit('/shout')
+                ->assertSee('Shout!')
+                ->type('title', 'New Stream Item')
+                ->type('body', 'Body of the stream item')
+                ->press('Shout!')
+                ->visit('/stream')
+                ->assertDontSeeIn('h4.shout-title', 'New Stream Item')
+                ->assertDontSeeIn('div.stream_body', 'Body of the stream item')
+                ->assertDontSeeIn('div.author', $user->fullName());
         });
     }
 }

--- a/tests/Browser/InvalidAnnouncementTest.php
+++ b/tests/Browser/InvalidAnnouncementTest.php
@@ -15,9 +15,36 @@ class InvalidAnnouncementTest extends DuskTestCase
 
     /**
      * Check that correct messaging displayed within modal for a message that fails validation
+     * No fields have been completed
+     *
+     * @group stream
+     * @group announcement
+     * @group invalid
+     * @return void
+     */
+    public function testCorrectConfirmationMessageStringsDisplayedForAnnouncementMissingAllData()
+    {
+        $user = User::find(3);
+
+        $this->browse(function ($broadcast) use ($user) {
+            $broadcast->loginAs($user)
+                ->visit('/shout')
+                ->assertSee('Shout!')
+                ->press('Shout!')
+                ->waitForText('Uh Oh!')
+                ->assertSee('Looks like you\'ve forgotten something. Try again')
+                ->visit('/stream')
+                ->assertDontSeeIn('div.author', $user->fullName());
+        });
+    }
+
+    /**
+     * Check that correct messaging displayed within modal for a message that fails validation
      * Title value has not been entered
      *
      * @group stream
+     * @group announcement
+     * @group invalid
      * @return void
      */
     public function testCorrectConfirmationMessageStringsDisplayedInModalForAnnouncementMissingTitle()
@@ -32,7 +59,10 @@ class InvalidAnnouncementTest extends DuskTestCase
                 ->select('type_id', (string) AnnouncementType::ANNOUNCEMENT_ID)
                 ->press('Shout!')
                 ->waitForText('Uh Oh!')
-                ->assertSee('Looks like you\'ve forgotten something. Try again');
+                ->assertSee('Looks like you\'ve forgotten something. Try again')
+                ->visit('/stream')
+                ->assertDontSeeIn('div.stream_body', 'Body of the stream item')
+                ->assertDontSeeIn('div.author', $user->fullName());
         });
     }
 
@@ -41,6 +71,8 @@ class InvalidAnnouncementTest extends DuskTestCase
      * Body value has not been entered
      *
      * @group stream
+     * @group announcement
+     * @group invalid
      * @return void
      */
     public function testCorrectConfirmationMessageStringsDisplayedInModalForAnnouncementMissingBody()
@@ -56,7 +88,9 @@ class InvalidAnnouncementTest extends DuskTestCase
                 ->press('Shout!')
                 ->waitForText('Uh Oh!')
                 ->assertSee('Looks like you\'ve forgotten something. Try again')
-                ->pause(3000);
+                ->visit('/stream')
+                ->assertDontSeeIn('h4.shout-title', 'New Stream Item')
+                ->assertDontSeeIn('div.author', $user->fullName());
         });
     }
 
@@ -64,8 +98,9 @@ class InvalidAnnouncementTest extends DuskTestCase
      * Check that correct messaging displayed within modal for a message that fails validation
      * Announcement type has not been selected from the drop down
      *
-     * @group single
      * @group stream
+     * @group announcement
+     * @group invalid
      * @return void
      */
     public function testCorrectConfirmationMessageStringsDisplayedInModalForAnnouncementWithoutSelectedType()

--- a/tests/Browser/ValidAnnouncementTest.php
+++ b/tests/Browser/ValidAnnouncementTest.php
@@ -17,6 +17,8 @@ class ValidAnnouncementTest extends DuskTestCase
      * Ensure a standard announcement is received and correctly displayed in the stream.
      *
      * @group stream
+     * @group announcement
+     * @group valid
      * @return void
      */
     public function testStandardAnnouncementIsCorrectlyDisplayedInStream()
@@ -35,7 +37,7 @@ class ValidAnnouncementTest extends DuskTestCase
             $stream->loginAs(User::find(4))
                 ->visit('/stream')
                 ->waitForText('New Stream Item')
-                ->assertSee('Body of the stream item')
+                ->assertSeeIn('div.stream_body', 'Body of the stream item')
                 ->assertSeeIn('div.author', $user->fullName());
         });
     }
@@ -44,6 +46,8 @@ class ValidAnnouncementTest extends DuskTestCase
      * Ensure the correct information and messaging is displayed in the modal
      *
      * @group stream
+     * @group announcement
+     * @group valid
      * @return void
      */
     public function testCorrectConfirmationMessageStringsDisplayedInModalForValidAnnouncement()

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -119,7 +119,7 @@ class TestBase extends TestCase
             'body'      => 'New application code successfully deployed',
             'type_id'   => AnnouncementType::CODE_DEPLOY_ID,
             'user_id'   => User::SYSTEM_USER_ID
-        ];w
+        ];
     }
 
     protected function createAnnouncementAttributes(User $user = null)


### PR DESCRIPTION
More robust testing around the strings displayed in modals when announcement inserts fail validation. The stream is also evaluated to ensure that failed announcements aren't present.