### PR TITLE
Valid announcement tests updated to use Page objects

### DIFF
--- a/tests/Browser/InvalidAnnouncementTest.php
+++ b/tests/Browser/InvalidAnnouncementTest.php
@@ -112,7 +112,7 @@ class InvalidAnnouncementTest extends DuskTestCase
                 ->select('@stream-item-type', (string) AnnouncementType::ANNOUNCEMENT_ID)
                 ->press('Shout!')
                 ->visit(new StreamPage)
-                ->assertDontSeeIn('@stream_body', 'Body of the stream item')
+                ->assertDontSeeIn('@stream-body', 'Body of the stream item')
                 ->assertDontSeeIn('@author', $user->fullName());
         });
     }
@@ -222,7 +222,7 @@ class InvalidAnnouncementTest extends DuskTestCase
                 ->press('Shout!')
                 ->visit(new StreamPage)
                 ->assertDontSeeIn('@shout-title', 'New Stream Item')
-                ->assertDontSeeIn('@stream_body', 'Body of the stream item')
+                ->assertDontSeeIn('@stream-body', 'Body of the stream item')
                 ->assertDontSeeIn('@author', $user->fullName());
         });
     }

--- a/tests/Browser/Pages/StreamPage.php
+++ b/tests/Browser/Pages/StreamPage.php
@@ -37,7 +37,7 @@ class StreamPage extends BasePage
     {
         return [
             '@author'       => 'div.author',
-            '@stream_body'  => 'div.stream_body',
+            '@stream-body'  => 'div.stream_body',
             '@shout-title'  => '.shout-title',
         ];
     }

--- a/tests/Browser/ValidAnnouncementTest.php
+++ b/tests/Browser/ValidAnnouncementTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Browser;
 
 use App\User;
+use Tests\Browser\Pages\ShoutPage;
+use Tests\Browser\Pages\StreamPage;
 use Tests\DuskTestCase;
 use App\AnnouncementType;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
@@ -27,18 +29,18 @@ class ValidAnnouncementTest extends DuskTestCase
 
         $this->browse(function ($broadcast, $stream) use ($user) {
             $broadcast->loginAs($user)
-                ->visit('/shout')
+                ->visit(new ShoutPage)
                 ->assertSee('Shout!')
-                ->type('title', 'New Stream Item')
-                ->type('body', 'Body of the stream item')
-                ->select('type_id', (string) AnnouncementType::ANNOUNCEMENT_ID)
+                ->type('@stream-item-title', 'New Stream Item')
+                ->type('@stream-item-body', 'Body of the stream item')
+                ->select('@stream-item-type', (string) AnnouncementType::ANNOUNCEMENT_ID)
                 ->press('Shout!');
 
             $stream->loginAs(User::find(4))
-                ->visit('/stream')
+                ->visit(new StreamPage)
                 ->waitForText('New Stream Item')
-                ->assertSeeIn('div.stream_body', 'Body of the stream item')
-                ->assertSeeIn('div.author', $user->fullName());
+                ->assertSeeIn('@stream-body', 'Body of the stream item')
+                ->assertSeeIn('@author', $user->fullName());
         });
     }
 
@@ -56,11 +58,11 @@ class ValidAnnouncementTest extends DuskTestCase
 
         $this->browse(function ($broadcast) use ($user) {
             $broadcast->loginAs($user)
-                ->visit('/shout')
+                ->visit(new ShoutPage)
                 ->assertSee('Shout!')
-                ->type('title', 'New Stream Item')
-                ->type('body', 'Body of the stream item')
-                ->select('type_id', (string) AnnouncementType::ANNOUNCEMENT_ID)
+                ->type('@stream-item-title', 'New Stream Item')
+                ->type('@stream-item-body', 'Body of the stream item')
+                ->select('@stream-item-type', (string) AnnouncementType::ANNOUNCEMENT_ID)
                 ->press('Shout!')
                 ->waitForText('Shout Heard!')
                 ->assertSee('Your Shout has been added to the burble');


### PR DESCRIPTION
Using the Page object selectors. The selectors are now all the same format - dashes not underscores